### PR TITLE
Depend on webmock

### DIFF
--- a/companies-house-ruby.gemspec
+++ b/companies-house-ruby.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop", "~> 0.41.2"
+  spec.add_development_dependency "webmock", "~> 2.1.0"
 end


### PR DESCRIPTION
We will use webmock to mock HTTP requests to test the future API client.
