### PR TITLE
Keep HTTP connection alive

### DIFF
--- a/lib/companies_house/client.rb
+++ b/lib/companies_house/client.rb
@@ -18,6 +18,10 @@ module CompaniesHouse
       raise ArgumentError, 'HTTP is not supported' if @endpoint.scheme != 'https'
     end
 
+    def end_connection
+      @connection.finish if @connection && @connection.started?
+    end
+
     def company(id)
       request(id)
     end
@@ -40,6 +44,12 @@ module CompaniesHouse
       end
 
       items
+    end
+
+    def connection
+      @connection ||= Net::HTTP.new(endpoint.host, endpoint.port).tap do |conn|
+        conn.use_ssl = true
+      end
     end
 
     private
@@ -68,12 +78,6 @@ module CompaniesHouse
       else
         raise CompaniesHouse::APIError.new("Unknown API response", response)
       end
-    end
-
-    def connection
-      @connection ||= Net::HTTP.new(endpoint.host, endpoint.port)
-      @connection.use_ssl = true
-      @connection
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -163,4 +163,20 @@ describe CompaniesHouse::Client do
       it_should_behave_like 'an API with consistent error handling'
     end
   end
+
+  describe '#end_connection' do
+    it 'should not throw an exception if not started' do
+      allow(client.connection).to receive(:started?).
+        and_return(false)
+
+      expect { client.end_connection }.not_to raise_error
+    end
+
+    it 'is idempotent' do
+      expect do
+        client.end_connection
+        client.end_connection
+      end.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This means that we aren't starting a new HTTP connection for every company we check the details of, which should save us time / network traffic if checking lots of details.
