### PR TITLE
Clean up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or install it yourself as:
 
 ## Usage
 
-### Authentication
+### Authentication
 
 Using the Companies House REST API requires you to register an account
 [here](https://beta.companieshouse.gov.uk). Once your account is confirmed you will be
@@ -47,7 +47,7 @@ hash are:
 | `:api_key` | Required. The API key received after registration. |
 | `:endpoint` | Optional. Specifies the base URI for the API (e.g. if using a self-hosted version) |
 
-### Making a Request
+### Making a Request
 
 Once a client has been initialised, requests can be made to the API. The endpoints
 currently implemented by the gem are:
@@ -61,7 +61,7 @@ Response data is given as a hash object directly obtained from the response JSON
 of the available fields in the response are in the Companies House
 [documentation](https://developer.companieshouse.gov.uk/api/docs/index.html).
 
-### Error Handling
+### Error Handling
 
 If a request to the API returns with a status code other than `200 OK`, no response data
 will be returned to the caller. Instead, an exception of type `CompaniesHouse::APIError`


### PR DESCRIPTION
This PR includes two changes:
1. Remove an extra use of "here" in opening paragraph
2. Replace UTF-8 spaces with ASCII spaces
