### PR TITLE
Fix console startup

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "companies/house/ruby"
+require "companies-house"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
The require path was wrong - fixing this allows a console to be started with all requirements included automatically.
