### PR TITLE
v0.2.1 corrects over-strict version requirement

### DIFF
--- a/companies-house-rest.gemspec
+++ b/companies-house-rest.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '~> 2.2.2'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency "activesupport", ">= 4.2"
   spec.add_runtime_dependency "virtus", '~> 1.0', '>= 1.0.5'

--- a/lib/companies_house/version.rb
+++ b/lib/companies_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CompaniesHouse
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Apparently pointing at the raw code at a Git repository in the Gemfile doesn't validate things like this, so we didn't catch it earlier.