### PR TITLE
Add endpoint for persons-with-significant-control

### DIFF
--- a/lib/companies_house/version.rb
+++ b/lib/companies_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CompaniesHouse
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/companies_house/client_spec.rb
+++ b/spec/companies_house/client_spec.rb
@@ -196,6 +196,79 @@ describe CompaniesHouse::Client do
     end
   end
 
+  describe "#persons_with_significant_control" do
+    include_context "test client"
+
+    subject(:response) { client.persons_with_significant_control(company_id) }
+
+    let(:rest_path) do
+      "company/#{company_id}/persons-with-significant-control?register_view=true"
+    end
+    let(:request_method) { "persons_with_significant_control" }
+
+    context "when all results are on a single page" do
+      let(:single_page) do
+        {
+          items_per_page: 2,
+          total_results: 2,
+          start_index: 0,
+          items: %w[item1 item2],
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{example_endpoint}/#{rest_path}").
+          with(
+            basic_auth: [api_key, ""],
+            query: { "start_index" => 0, register_view: true },
+          ).to_return(body: single_page, status: status)
+      end
+
+      it "returns items from the one, single page" do
+        expect(response).to eq(%w[item1 item2])
+      end
+    end
+
+    context "when results are spread across several pages" do
+      let(:page1) do
+        {
+          items_per_page: 1,
+          total_results: 2,
+          start_index: 0,
+          items: ["item1"],
+        }.to_json
+      end
+
+      let(:page2) do
+        {
+          items_per_page: 1,
+          total_results: 2,
+          start_index: 1,
+          items: ["item2"],
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{example_endpoint}/#{rest_path}").
+          with(
+            basic_auth: [api_key, ""],
+            query: { "start_index" => 0, register_view: true },
+          ).
+          to_return(body: page1, status: status)
+        stub_request(:get, "#{example_endpoint}/#{rest_path}").
+          with(
+            basic_auth: [api_key, ""],
+            query: { "start_index" => 1, register_view: true },
+          ).
+          to_return(body: page2, status: status)
+      end
+
+      it "returns items from all pages" do
+        expect(response).to eq(%w[item1 item2])
+      end
+    end
+  end
+
   describe "#company_search" do
     include_context "test client"
 


### PR DESCRIPTION
I've moved the pagination logic from `officers` into a shared method, since we need it for this too. I've also reused most of the tests, but not bothered with the notification ones since the new method doesn't really touch them.