### PR TITLE
Allow register_view to be specified for persons-with-significant-control

### DIFF
--- a/lib/companies_house/client.rb
+++ b/lib/companies_house/client.rb
@@ -31,12 +31,12 @@ module CompaniesHouse
       get_all_pages(:officers, "company/#{id}/officers", id)
     end
 
-    def persons_with_significant_control(id)
+    def persons_with_significant_control(id, register_view: false)
       get_all_pages(
         :persons_with_significant_control,
         "company/#{id}/persons-with-significant-control",
         id,
-        register_view: true,
+        register_view: register_view,
       )
     end
 

--- a/lib/companies_house/version.rb
+++ b/lib/companies_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CompaniesHouse
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/companies_house/client_spec.rb
+++ b/spec/companies_house/client_spec.rb
@@ -199,12 +199,16 @@ describe CompaniesHouse::Client do
   describe "#persons_with_significant_control" do
     include_context "test client"
 
-    subject(:response) { client.persons_with_significant_control(company_id) }
+    subject(:response) do
+      client.persons_with_significant_control(company_id, register_view: register_view)
+    end
 
     let(:rest_path) do
-      "company/#{company_id}/persons-with-significant-control?register_view=true"
+      "company/#{company_id}/persons-with-significant-control" \
+        "?register_view=#{register_view}"
     end
     let(:request_method) { "persons_with_significant_control" }
+    let(:register_view) { true }
 
     context "when all results are on a single page" do
       let(:single_page) do
@@ -220,12 +224,20 @@ describe CompaniesHouse::Client do
         stub_request(:get, "#{example_endpoint}/#{rest_path}").
           with(
             basic_auth: [api_key, ""],
-            query: { "start_index" => 0, register_view: true },
+            query: { "start_index" => 0, register_view: register_view },
           ).to_return(body: single_page, status: status)
       end
 
       it "returns items from the one, single page" do
         expect(response).to eq(%w[item1 item2])
+      end
+
+      context "with register_view: false" do
+        let(:register_view) { false }
+
+        it "returns items from the one, single page" do
+          expect(response).to eq(%w[item1 item2])
+        end
       end
     end
 


### PR DESCRIPTION
`register_view` determines whether companies house will pull from an official register for UBOs, or rely on user-submitted data. Not many companies store their official UBO data in companies house, so defaulting this to true means you don't get very many results.

This PR allows you to specify `register_view` when you make the API call.