### PR TITLE
Fix gemspec dependency bounds

### DIFF
--- a/companies-house-rest.gemspec
+++ b/companies-house-rest.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_runtime_dependency "activesupport", ">= 4.2"
+  spec.add_runtime_dependency "activesupport", "~> 4.2"
   spec.add_runtime_dependency "virtus", "~> 1.0", ">= 1.0.5"
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "gc_ruboconfig", "~> 2.3.1"
+  spec.add_development_dependency "gc_ruboconfig", "~> 2.3"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "timecop", "~> 0.8"


### PR DESCRIPTION
Relax the gc_ruboconfig bound, and make the activesupport bound
stricter. This removes warnings during `gem build` and is also just a
sensible idea.