### PR TITLE
Relax activesupport bounds

### DIFF
--- a/companies-house-rest.gemspec
+++ b/companies-house-rest.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_runtime_dependency "activesupport", "~> 4.2"
+  spec.add_runtime_dependency "activesupport", ">= 4.2", "< 6"
   spec.add_runtime_dependency "virtus", "~> 1.0", ">= 1.0.5"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/companies_house/version.rb
+++ b/lib/companies_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CompaniesHouse
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION
Permit 2.4 <= activesupport < 6, which allows easier integration with
codebases on activesupport 5.x