### PR TITLE
Fix *args usage in ActiveSupport instrumenter

### DIFF
--- a/lib/companies_house/instrumentation/active_support.rb
+++ b/lib/companies_house/instrumentation/active_support.rb
@@ -3,7 +3,7 @@
 module Instrumentation
   class ActiveSupport
     def self.publish(*args)
-      ::ActiveSupport::Notifications.publish(**args)
+      ::ActiveSupport::Notifications.publish(*args)
     end
   end
 end

--- a/spec/companies_house/client_spec.rb
+++ b/spec/companies_house/client_spec.rb
@@ -186,7 +186,7 @@ describe CompaniesHouse::Client do
             response: JSON[page1],
             status: status.to_s,
           ),
-        )
+        ).and_call_original
         expect(client.instrumentation).to receive(:publish).with(
           "companies_house.officers",
           kind_of(Time),
@@ -199,7 +199,7 @@ describe CompaniesHouse::Client do
             response: JSON[page2],
             status: status.to_s,
           ),
-        )
+        ).and_call_original
 
         response
       end


### PR DESCRIPTION
Fixes:

```
     ArgumentError:
       wrong number of arguments (given 4, expected 0)
     # ~/.rvm/gems/ruby-2.5.5/gems/companies-house-rest-0.4.6/lib/companies_house/instrumentation/active_support.rb:5:in `publish'
     # ~/.rvm/gems/ruby-2.5.5/gems/companies-house-rest-0.4.6/lib/companies_house/request.rb:73:in `publish_notification'
     # ~/.rvm/gems/ruby-2.5.5/gems/companies-house-rest-0.4.6/lib/companies_house/request.rb:64:in `ensure in execute'
```