### PR TITLE
Require net/http from Request

### DIFF
--- a/lib/companies_house/request.rb
+++ b/lib/companies_house/request.rb
@@ -7,6 +7,7 @@ require "companies_house/rate_limit_error"
 require "companies_house/timeout_error"
 require "companies_house/bad_gateway_error"
 
+require "net/http"
 require "virtus"
 require "uri"
 require "json"


### PR DESCRIPTION
It's used there, but required _after_ request.rb is required in
client.rb. This can cause exceptions with the Virtus definitions if
net/http is not loaded before this gem.