### PR TITLE
Replace Virtus for dry-struct

### DIFF
--- a/companies-house-rest.gemspec
+++ b/companies-house-rest.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.5.5"
 
-  spec.add_runtime_dependency "virtus", "~> 1.0", ">= 1.0.5"
+  spec.add_runtime_dependency "dry-struct", "~> 1"
 
   spec.add_development_dependency "activesupport", ">= 4.2", "< 7"
   spec.add_development_dependency "gc_ruboconfig", "~> 2.4"

--- a/lib/companies_house/request.rb
+++ b/lib/companies_house/request.rb
@@ -10,7 +10,7 @@ require "companies_house/bad_gateway_error"
 require "net/http"
 require "uri"
 require "json"
-require 'dry-struct'
+require "dry-struct"
 
 module CompaniesHouse
   # This class manages individual requests.
@@ -48,11 +48,7 @@ module CompaniesHouse
 
     def execute
       @started = Time.now.utc
-
-      req = Net::HTTP::Get.new(@uri)
-      req.basic_auth api_key, ""
-
-      response = connection.request req
+      response = request_resource(@uri)
       @notification_payload[:status] = response.code
 
       begin
@@ -68,6 +64,13 @@ module CompaniesHouse
     end
 
     private
+
+    def request_resource(uri)
+      req = Net::HTTP::Get.new(uri)
+      req.basic_auth api_key, ""
+
+      connection.request req
+    end
 
     def publish_notification
       instrumentation.publish(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,7 +93,7 @@ shared_examples "sends one notification" do
     i = 0
     allow(SecureRandom).to receive(:hex).with(10) do
       i += 1
-      sprintf("RANDOM%04d", i)
+      sprintf("RANDOM%<i>04d", i: i)
     end
 
     expected_payload = {


### PR DESCRIPTION
This PR:
- Removes discontinued [Virtus](https://github.com/solnic/virtus)
- Adds [dry-struct](https://dry-rb.org/gems/dry-struct)

See https://github.com/gocardless/companies-house-rest/issues/64

This might be a breaking change since Virtus was raising an `ArgumentError` if a required attribute was missing and dry-struct raises a `Dry::Struct::Error`