### PR TITLE
Get filing history and arbitary headers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Metrics/MethodLength:
 
 RSpec/NestedGroups:
   Max: 8
+
+Metrics/ParameterLists:
+  Max: 6

--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ This method implements the [searchCompanies](https://developer.companieshouse.go
 API and returns the list of [companySearch](https://developer.companieshouse.gov.uk/api/docs/search-overview/CompanySearch-resource.html)
 resources that match the given query. The `items_per_page` and `start_index` parameters are optional.
 
+### .filing_history_list
+This method implements the [filingHistoryList](https://developer.companieshouse.gov.uk/api/docs/company/company_number/filing-history/getFilingHistoryList.html) API and returns the full [filingHistoryList](https://developer.companieshouse.gov.uk/api/docs/company/company_number/filing-history/filingHistoryList-resource.html) resource.
+
+### .filing_history_item
+This method implements the [filingHistoryItem](https://developer.companieshouse.gov.uk/api/docs/company/company_number/filing-history/transaction_id/getFilingHistoryItem.html) API and returns the full
+[filingHistoryItem](https://developer.companieshouse.gov.uk/api/docs/company/company_number/filing-history/filingHistoryItem-resource.html) resource.
+
 ### Other API Methods
 While there are other resources exposed by the
 [Companies House API](https://developer.companieshouse.gov.uk/api/docs/index.html),

--- a/lib/companies_house/client.rb
+++ b/lib/companies_house/client.rb
@@ -47,6 +47,17 @@ module CompaniesHouse
       )
     end
 
+    def filing_history_list(id)
+      get_all_pages(:filing_history_list, "company/#{id}/filing-history", id)
+    end
+
+    def filing_history_item(id, transaction_id)
+      request(
+        :filing_history_item,
+        "company/#{id}/filing-history/#{transaction_id}",
+      )
+    end
+
     def company_search(query, items_per_page: nil, start_index: nil)
       request(
         :company_search,
@@ -93,7 +104,8 @@ module CompaniesHouse
                 path,
                 params = {},
                 transaction_id = make_transaction_id,
-                resource_id = nil)
+                resource_id = nil,
+                headers = {})
       Request.new(
         connection: connection,
         api_key: @api_key,
@@ -104,6 +116,7 @@ module CompaniesHouse
         resource_id: resource_id,
         transaction_id: transaction_id,
         instrumentation: instrumentation,
+        headers: headers,
       ).execute
     end
 

--- a/lib/companies_house/client.rb
+++ b/lib/companies_house/client.rb
@@ -74,6 +74,26 @@ module CompaniesHouse
       end
     end
 
+    def request(resource,
+                path,
+                params = {},
+                transaction_id = make_transaction_id,
+                resource_id = nil,
+                headers = {})
+      Request.new(
+        connection: connection,
+        api_key: @api_key,
+        endpoint: @endpoint,
+        path: path,
+        query: params,
+        resource_type: resource,
+        resource_id: resource_id,
+        transaction_id: transaction_id,
+        instrumentation: instrumentation,
+        headers: headers,
+      ).execute
+    end
+
     private
 
     # Fetch and combine all pages of a paginated API call
@@ -98,26 +118,6 @@ module CompaniesHouse
 
     def make_transaction_id
       SecureRandom.hex(10)
-    end
-
-    def request(resource,
-                path,
-                params = {},
-                transaction_id = make_transaction_id,
-                resource_id = nil,
-                headers = {})
-      Request.new(
-        connection: connection,
-        api_key: @api_key,
-        endpoint: @endpoint,
-        path: path,
-        query: params,
-        resource_type: resource,
-        resource_id: resource_id,
-        transaction_id: transaction_id,
-        instrumentation: instrumentation,
-        headers: headers,
-      ).execute
     end
 
     def configure_instrumentation(instrumentation)

--- a/lib/companies_house/request.rb
+++ b/lib/companies_house/request.rb
@@ -25,6 +25,7 @@ module CompaniesHouse
     # Physical request attributes
     attribute :path, Dry.Types::String
     attribute :query, Dry.Types::Hash
+    attribute :headers, Dry.Types::Hash
 
     # Logical request attributes
     attribute :resource_type, Dry.Types::Symbol
@@ -82,10 +83,12 @@ module CompaniesHouse
       )
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def parse(response, resource_type, resource_id)
       case response.code
       when "200"
         JSON[response.body]
+      when "302" then { 'location': response["location"] }
       when "401"
         raise CompaniesHouse::AuthenticationError, response
       when "404"
@@ -98,5 +101,6 @@ module CompaniesHouse
         raise CompaniesHouse::APIError.new("Unknown API response", response)
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
   end
 end


### PR DESCRIPTION
This PR adds filing history and filing history items to the wrapper.

The arbitrary headers are required to send an `Accept` header for the document resource of a filing history item.

The 302 allows to follow a redirect - most documents appear to provide a permanent key which redirects to a temporary storage key.