### PR TITLE
Add workflow config to publish gem releases to GC repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Publish gem to GitHub package registry
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checkout repo containing common GitHub action
+        uses: actions/checkout@v2
+        with:
+          repository: gocardless/publish-internal-gem
+          ssh-key: ${{ secrets.HACK_RB_DEPLOY_KEY }}
+          path: ./.github/workflows/publish-internal-gem
+      - name: Publish Gem
+        uses: ./.github/workflows/publish-internal-gem
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/companies-house-rest.gemspec
+++ b/companies-house-rest.gemspec
@@ -22,6 +22,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.0.2"
 
+  spec.metadata              = {
+    "github_repo" => "ssh://github.com/gocardless/companies-house-rest",
+    "allowed_push_host" => "https://rubygems.pkg.github.com/gocardless",
+    "rubygems_mfa_required" => "true",
+  }
+
   spec.add_runtime_dependency "dry-struct", "~> 1"
 
   spec.add_development_dependency "activesupport", ">= 4.2", "< 7"


### PR DESCRIPTION
Adds a workflow so that releases can be created via Github and automatically pushed to GC's gem repository