### PR TITLE
Drop minimum Ruby version from 3.0.2 to 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [3.0, 3.1]
+        ruby_version: [2.7, 3.0, 3.1]
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.7
 
 Metrics/MethodLength:
   Max: 15

--- a/companies-house-rest.gemspec
+++ b/companies-house-rest.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 3.0.2"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata              = {
     "github_repo" => "ssh://github.com/gocardless/companies-house-rest",


### PR DESCRIPTION
I forgot when increasing this that there may be non-GC users who might need a lower version, and it was only really 2.5 (and maybe 2.6) that we actually _needed_ to drop support for

Not sure if we want to merge this or not, but it's here in case it is wanted