### PR TITLE
Update Rubocop config and fix/ignore new violations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,12 @@ source 'https://rubygems.org'
 
 # See companies-house.gemspec
 gemspec
+
+# Development dependencies
+gem "activesupport", ">= 4.2", "< 7"
+gem "gc_ruboconfig", "~> 5.0"
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.5"
+gem "rspec_junit_formatter", "~> 0.4.1"
+gem "timecop", "~> 0.8"
+gem "webmock", "~> 3.0"

--- a/companies-house-rest.gemspec
+++ b/companies-house-rest.gemspec
@@ -22,14 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.0.2"
 
-  spec.add_runtime_dependency "dry-struct", "~> 1"
+  spec.add_dependency "dry-struct", "~> 1"
 
-  spec.add_development_dependency "activesupport", ">= 4.2", "< 7"
-  spec.add_development_dependency "gc_ruboconfig", "~> 3.6"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.1"
-  spec.add_development_dependency "timecop", "~> 0.8"
-  spec.add_development_dependency "webmock", "~> 3.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/companies_house/request.rb
+++ b/lib/companies_house/request.rb
@@ -35,7 +35,7 @@ module CompaniesHouse
     attribute :instrumentation, Dry.Types.Interface(:publish)
 
     def initialize(args)
-      super(args)
+      super
 
       @uri = URI.join(endpoint, path)
       @uri.query = URI.encode_www_form(query)

--- a/lib/companies_house/version.rb
+++ b/lib/companies_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CompaniesHouse
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/companies_house/client_spec.rb
+++ b/spec/companies_house/client_spec.rb
@@ -6,6 +6,28 @@ require "json"
 describe CompaniesHouse::Client do
   before { WebMock.disable_net_connect! }
 
+  shared_context "multiple pages" do
+    # rubocop:disable RSpec/IndexedLet
+    let(:page1) do
+      {
+        items_per_page: 1,
+        total_results: 2,
+        start_index: 0,
+        items: ["item1"],
+      }.to_json
+    end
+
+    let(:page2) do
+      {
+        items_per_page: 1,
+        total_results: 2,
+        start_index: 1,
+        items: ["item2"],
+      }.to_json
+    end
+    # rubocop:enable RSpec/IndexedLet
+  end
+
   describe "#initialize" do
     include_context "test credentials"
     describe "with an API key" do
@@ -142,23 +164,7 @@ describe CompaniesHouse::Client do
     end
 
     context "when results are spread across several pages" do
-      let(:page1) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 0,
-          items: ["item1"],
-        }.to_json
-      end
-
-      let(:page2) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 1,
-          items: ["item2"],
-        }.to_json
-      end
+      include_context "multiple pages"
 
       before do
         stub_request(:get, "#{example_endpoint}/#{rest_path}").
@@ -268,23 +274,7 @@ describe CompaniesHouse::Client do
     end
 
     context "when results are spread across several pages" do
-      let(:page1) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 0,
-          items: ["item1"],
-        }.to_json
-      end
-
-      let(:page2) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 1,
-          items: ["item2"],
-        }.to_json
-      end
+      include_context "multiple pages"
 
       before do
         stub_request(:get, "#{example_endpoint}/#{rest_path}").
@@ -354,23 +344,7 @@ describe CompaniesHouse::Client do
     end
 
     context "when results are spread across several pages" do
-      let(:page1) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 0,
-          items: ["item1"],
-        }.to_json
-      end
-
-      let(:page2) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 1,
-          items: ["item2"],
-        }.to_json
-      end
+      include_context "multiple pages"
 
       before do
         stub_request(:get, "#{example_endpoint}/#{rest_path}").
@@ -517,23 +491,7 @@ describe CompaniesHouse::Client do
     end
 
     context "when results are spread across several pages" do
-      let(:page1) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 0,
-          items: ["item1"],
-        }.to_json
-      end
-
-      let(:page2) do
-        {
-          items_per_page: 1,
-          total_results: 2,
-          start_index: 1,
-          items: ["item2"],
-        }.to_json
-      end
+      include_context "multiple pages"
 
       before do
         stub_request(:get, "#{example_endpoint}/#{rest_path}").


### PR DESCRIPTION
PRs no longer build because they're using a newer version of Rubocop which requires a newer version of the `gc_ruboconfig` dependency

This PR updates that, and addresses all the new Rubocop violations that come up as a result of that