### PR TITLE
 Export response status in companies_house request metrics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         ruby_version: [3.0, 3.1, 3.2, 3.3]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
@@ -20,7 +20,7 @@ jobs:
             --out /tmp/test-results/rspec.xml \
             --format progress \
             spec
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-results

--- a/lib/companies_house/request.rb
+++ b/lib/companies_house/request.rb
@@ -50,7 +50,7 @@ module CompaniesHouse
     def execute
       @started = Time.now.utc
       response = request_resource(@uri)
-      @notification_payload[:status] = response.code
+      @notification_payload[:response_status] = response.code
 
       begin
         @notification_payload[:response] = parse(response, resource_type, resource_id)

--- a/lib/companies_house/version.rb
+++ b/lib/companies_house/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CompaniesHouse
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/spec/companies_house/client_spec.rb
+++ b/spec/companies_house/client_spec.rb
@@ -192,7 +192,7 @@ describe CompaniesHouse::Client do
             path: rest_path,
             query: { start_index: 0 },
             response: JSON[page1],
-            status: status.to_s,
+            response_status: status.to_s,
           ),
         ).and_call_original
         expect(client.instrumentation).to receive(:publish).with(
@@ -205,7 +205,7 @@ describe CompaniesHouse::Client do
             path: rest_path,
             query: { start_index: 1 },
             response: JSON[page2],
-            status: status.to_s,
+            response_status: status.to_s,
           ),
         ).and_call_original
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,7 @@ shared_examples "sends one notification" do
       method: :get,
       path: rest_path,
       query: rest_query,
-      status: status.to_s,
+      response_status: status.to_s,
     }
 
     if error_class


### PR DESCRIPTION
We [recently](https://github.com/gocardless/payments-service/pull/57449/files#diff-36fda65dc2ffda42fd884691ceb2af53a7c0dd67b0d3179c5910ebbed80fc859R56) started capturing `response_status` in our third party API requests. To make companies house comptible with this change I have renamed status to response status.

--

GH artifact action has been [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) so I bumped the version