### PR TITLE
Update supported ruby versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [3.0, 3.1, 3.2, 3.3]
+        ruby_version: [3.2, 3.3, 3.4]
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This matches the currently supported versions of ruby:

https://www.ruby-lang.org/en/downloads/branches/