### PR TITLE
Run Github Actions workflows on PRs as well as pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: main
-on: push
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - master
 
 jobs:
   tests:


### PR DESCRIPTION
Running the actions on a `push` event works fine for PRs created by GoCardless employees, as we can create branches in the repository to push to and create PRs from. PRs from contributors come from forks though, so I believe that the `push` event is not happening and that's why the workflow isn't running.

To resolve this, run the workflow when PRs are opened, reopened or have commits pushed to them (`synchronize`) and also when code is pushed to the `master` branch